### PR TITLE
Cache last image before load

### DIFF
--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -3293,6 +3293,14 @@ function initWallpanel() {
 			this.restartProgressBarAnimation();
 			this.restartKenBurnsEffect();
 
+			try {
+				if (window.localStorage && newMedia.src) {
+					localStorage.setItem("wallpanel-last-image", newMedia.src);
+				}
+			} catch (e) {
+				logger.debug("Failed to store last image", e);
+			}
+
 			if (curMedia.tagName.toLowerCase() === "video") {
 				this.afterFadeoutTimer = setTimeout(function () {
 					if (curMedia.tagName.toLowerCase() === "video") {
@@ -3382,6 +3390,16 @@ function initWallpanel() {
 			} else {
 				this.imageOneContainer.style.opacity = 0;
 				this.imageTwoContainer.style.opacity = 1;
+			}
+
+			try {
+				const lastImage = window.localStorage && localStorage.getItem("wallpanel-last-image");
+				if (lastImage) {
+					this.imageOne.src = lastImage;
+					this.imageTwo.src = lastImage;
+				}
+			} catch (e) {
+				logger.debug("Failed to load last image", e);
 			}
 
 			await this.switchActiveMedia("start");

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -3796,6 +3796,13 @@ function initWallpanel() {
         this.startPlayingActiveMedia();
         this.restartProgressBarAnimation();
         this.restartKenBurnsEffect();
+        try {
+          if (window.localStorage && newMedia.src) {
+            localStorage.setItem("wallpanel-last-image", newMedia.src);
+          }
+        } catch (e) {
+          logger.debug("Failed to store last image", e);
+        }
         if (curMedia.tagName.toLowerCase() === "video") {
           this.afterFadeoutTimer = setTimeout(function () {
             if (curMedia.tagName.toLowerCase() === "video") {
@@ -3871,7 +3878,7 @@ function initWallpanel() {
       key: "startScreensaver",
       value: function () {
         var _startScreensaver = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee19() {
-          var activeElement, _wp;
+          var activeElement, lastImage, _wp;
           return _regenerator().w(function (_context19) {
             while (1) switch (_context19.n) {
               case 0:
@@ -3898,6 +3905,15 @@ function initWallpanel() {
                 } else {
                   this.imageOneContainer.style.opacity = 0;
                   this.imageTwoContainer.style.opacity = 1;
+                }
+                try {
+                  lastImage = window.localStorage && localStorage.getItem("wallpanel-last-image");
+                  if (lastImage) {
+                    this.imageOne.src = lastImage;
+                    this.imageTwo.src = lastImage;
+                  }
+                } catch (e) {
+                  logger.debug("Failed to load last image", e);
                 }
                 _context19.n = 2;
                 return this.switchActiveMedia("start");


### PR DESCRIPTION
## Summary
- preserve last displayed media
- reuse cached image when screensaver is started

## Testing
- `npx eslint wallpanel-src.js` *(fails: compat issues)*
- `npx eslint --fix wallpanel-src.js` *(fails: compat issues)*
- `npx babel wallpanel-src.js --out-file wallpanel.js`


------
https://chatgpt.com/codex/tasks/task_e_685f1ebef8bc832d82c3184ec237c6b9